### PR TITLE
Port shaders over to nihstro syntax.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ ifeq ($(strip $(DEVKITARM)),)
 $(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
 endif
 
+ifeq ($(strip $(NIHSTRO)),)
+$(error "Please set NIHSTRO in your environment. export NIHSTRO=<path to>nihstro-assemble")
+endif
+
 TOPDIR ?= $(CURDIR)
 include $(DEVKITARM)/3ds_rules
 
@@ -158,10 +162,19 @@ $(OUTPUT).elf	:	$(OFILES)
 
 # WARNING: This is not the right way to do this! TODO: Do it right!
 #---------------------------------------------------------------------------------
-%.vsh.o	:	%.vsh
+v%.vsh.o: v%.vsh
 #---------------------------------------------------------------------------------
 	@echo $(notdir $<)
-	@python $(AEMSTRO)/aemstro_as.py $< ../$(notdir $<).shbin
+	@$(NIHSTRO)/nihstro-assemble -e vmain --output ../$(notdir $<).shbin $<
+	@bin2s ../$(notdir $<).shbin | $(PREFIX)as -o $@
+	@echo "extern const u8" `(echo $(notdir $<).shbin | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"_end[];" > `(echo $(notdir $<).shbin | tr . _)`.h
+	@echo "extern const u8" `(echo $(notdir $<).shbin | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"[];" >> `(echo $(notdir $<).shbin | tr . _)`.h
+	@echo "extern const u32" `(echo $(notdir $<).shbin | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`_size";" >> `(echo $(notdir $<).shbin | tr . _)`.h
+	@rm ../$(notdir $<).shbin
+
+g%.vsh.o: g%.vsh
+	@echo $(notdir $<)
+	@$(NIHSTRO)/nihstro-assemble -g -e gmain --output ../$(notdir $<).shbin $<
 	@bin2s ../$(notdir $<).shbin | $(PREFIX)as -o $@
 	@echo "extern const u8" `(echo $(notdir $<).shbin | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"_end[];" > `(echo $(notdir $<).shbin | tr . _)`.h
 	@echo "extern const u8" `(echo $(notdir $<).shbin | sed -e 's/^\([0-9]\)/_\1/' | tr . _)`"[];" >> `(echo $(notdir $<).shbin | tr . _)`.h

--- a/data/gfinal.vsh
+++ b/data/gfinal.vsh
@@ -1,80 +1,70 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
-	.const c5, 0.0, 0.0, 0.0, 1.0
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
-	.out o2, result.texcoord0, 0x3
- 
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
 
-	.gsh gmain, end_gmain
- 
-;code
-	gmain:
-		; turn two vertices into a rectangle
-		; setemit: vtxid, primemit, winding
-		
-		; v0 = vertex 0, position
-		; v1 = vertex 0, texcoord
-		; v2 = vertex 1, position
-		; v3 = vertex 1, texcoord
-		
-		; x1 y1
-		setemit vtx0, false, false
-		mov o0, v0 (0x0)
-		mov o1, c5 (0x3)
-		mov o2, v1 (0x0)
-		emit
-		
-		; x2 y1
-		setemit vtx1, false, false
-		mov o0, v2 (0x1)
-		mov o0, v0 (0x2)
-		mov o1, c5 (0x3)
-		mov o2, v1 (0x1)
-		mov o2, v3 (0x2)
-		emit
-		
-		; x1 y2
-		setemit vtx2, true, false
-		mov o0, v0 (0x1)
-		mov o0, v2 (0x2)
-		mov o1, c5 (0x3)
-		mov o2, v3 (0x1)
-		mov o2, v1 (0x2)
-		emit
-		
-		; x2 y2
-		setemit vtx0, true, true
-		mov o0, v2 (0x0)
-		mov o1, c5 (0x3)
-		mov o2, v3 (0x0)
-		emit
-		
-		end
-		nop
-	end_gmain:
- 
-;operand descriptors
-	.opdesc xyzw, xyzw, xyzw ; 0x0
-	.opdesc x_zw, xyzw, xyzw ; 0x1
-	.opdesc _y__, yyyw, xyzw ; 0x2
-	.opdesc xyzw, wwww, wwww ; 0x3
+// setup constants
+.alias myconst c5 as (0.0, 0.0, 0.0, 1.0)
+
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
+.alias resulttex0     o2.xy as texcoord0
+
+gmain:
+	// turn two vertices into a rectangle
+	// setemit: vtxid, primemit, winding
+
+	// v0 = vertex 0, position
+	// v1 = vertex 0, texcoord
+	// v2 = vertex 1, position
+	// v3 = vertex 1, texcoord
+
+	// x1 y1
+	setemitraw 0
+	mov o0, v0
+	mov o1, c5.wwww
+	mov o2, v1
+	emit
+
+	// x2 y1
+	setemitraw 1
+	mov o0.xzw, v2.xzw
+	mov o0.y, v0.y
+	mov o1, c5.wwww
+	mov o2.xzw, v1.xzw
+	mov o2.y, v3.y
+	emit
+
+	// x1 y2
+	setemitraw 2, prim
+	mov o0.xzw, v0.xzw
+	mov o0.y, v2.y
+	mov o1, c5.wwww
+	mov o2.xzw, v3.xzw
+	mov o2.y, v1.y
+	emit
+
+	// x2 y2
+	setemitraw 0, prim, inv
+	mov o0, v2
+	mov o1, c5.wwww
+	mov o2, v3
+	emit
+
+	end
+	nop
+end_gmain:

--- a/data/gplain_quad.vsh
+++ b/data/gplain_quad.vsh
@@ -1,77 +1,69 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
- 
-; setup uniform map (not required)
-	.uniform c0, c3, projMtx
-	
-	.gsh gmain, end_gmain
-	
-; input
-; v0: XYZ coordinates
-; v1: color
- 
-;code
-	gmain:
-		; turn two vertices into a rectangle
-		; setemit: vtxid, primemit, winding
-		
-		; v0 = vertex 0, position
-		; v1 = vertex 0, color
-		; v2 = vertex 1, position
-		; v3 = vertex 1, color
-		
-		; x1 y1
-		setemit vtx0, false, false
-		mov o0, v0 (0x0)
-		mov o1, v1 (0x0)
-		emit
-		
-		; x2 y1
-		setemit vtx1, false, false
-		mov o0, v2 (0x1)
-		mov o0, v0 (0x2)
-		mov o1, v3 (0x0)
-		emit
-		
-		; x1 y2
-		setemit vtx2, true, false
-		mov o0, v0 (0x1)
-		mov o0, v2 (0x2)
-		mov o1, v1 (0x0)
-		emit
-		
-		; x2 y2
-		setemit vtx0, true, true
-		mov o0, v2 (0x0)
-		mov o1, v3 (0x0)
-		emit
-		
-		end
-		nop
-	end_gmain:
- 
-;operand descriptors
-	.opdesc xyzw, xyzw, xyzw ; 0x0
-	.opdesc x_zw, xyzw, xyzw ; 0x1
-	.opdesc _y__, yyyw, xyzw ; 0x2
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
+
+// setup constants
+
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
+
+// setup uniform map (not required)
+.alias projMtx c0-c3
+
+// input
+// v0: XYZ coordinates
+// v1: color
+
+gmain:
+	// turn two vertices into a rectangle
+	// setemit: vtxid, primemit, winding
+
+	// v0 = vertex 0, position
+	// v1 = vertex 0, color
+	// v2 = vertex 1, position
+	// v3 = vertex 1, color
+
+	// x1 y1
+	setemitraw 0
+	mov o0, v0
+	mov o1, v1
+	emit
+
+	// x2 y1
+	setemitraw 1
+	mov o0.xzw, v2.xzw
+	mov o0.y, v0.y
+	mov o1, v3
+	emit
+
+	// x1 y2
+	setemitraw 2, prim
+	mov o0.xzw, v0.xzw
+	mov o0.y, v2.y
+	mov o1, v1
+	emit
+
+	// x2 y2
+	setemitraw 0, prim, inv
+	mov o0, v2
+	mov o1, v3
+	emit
+
+	end
+	nop
+end_gmain:

--- a/data/grender_hard.vsh
+++ b/data/grender_hard.vsh
@@ -1,90 +1,81 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
-	.const c9, 0.0, 0.0, 0.0078125, 1.0
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
-	.out o2, result.texcoord0, 0x3
- 
-; setup uniform map (not required)
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
 
-		
-	.gsh gmain, end_gmain
-	
-; INPUT
-; - VERTEX ATTRIBUTES -
-; v0: vertex (x, y, and optional z)
-; v1: texcoord
-; - UNIFORMS -
-; c0-c3: projection matrix
-; c4: texcoord scale
- 
-;code
-	gmain:
-		; turn two vertices into a rectangle
-		; setemit: vtxid, primemit, winding
-		
-		; v0 = vertex 0, position
-		; v1 = vertex 0, texcoord
-		; v2 = vertex 1, position
-		; v3 = vertex 1, texcoord
-		
-		; x1 y1
-		setemit vtx0, false, false
-		mov o0, v0 (0x0)
-		mov o1, c9 (0x3)
-		mov o2, v1 (0x0)
-		emit
-		
-		; x2 y1
-		setemit vtx1, false, false
-		mov o0, v2 (0x1)
-		mov o0, v0 (0x2)
-		mov o1, c9 (0x3)
-		mov o2, v3 (0x1)
-		mov o2, v1 (0x2)
-		emit
-		
-		; x1 y2
-		setemit vtx2, true, false
-		mov o0, v0 (0x1)
-		mov o0, v2 (0x2)
-		mov o1, c9 (0x3)
-		mov o2, v1 (0x1)
-		mov o2, v3 (0x2)
-		emit
-		
-		; x2 y2
-		setemit vtx0, true, true
-		mov o0, v2 (0x0)
-		mov o1, c9 (0x3)
-		mov o2, v3 (0x0)
-		emit
-		
-		end
-		nop
-	end_gmain:
- 
-;operand descriptors
-	.opdesc xyzw, xyzw, xyzw ; 0x0
-	.opdesc x_zw, xyzw, xyzw ; 0x1
-	.opdesc _y__, yyyw, xyzw ; 0x2
-	.opdesc xyzw, wwww, wwww ; 0x3
+// setup constants
+.alias myconst c9 as (0.0, 0.0, 0.0078125, 1.0)
+
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
+.alias resulttex0     o2.xy as texcoord0
+
+// setup uniform map (not required)
+
+// INPUT
+// - VERTEX ATTRIBUTES -
+// v0: vertex (x, y, and optional z)
+// v1: texcoord
+// - UNIFORMS -
+// c0-c3: projection matrix
+// c4: texcoord scale
+
+gmain:
+	// turn two vertices into a rectangle
+	// setemit: vtxid, primemit, winding
+
+	// v0 = vertex 0, position
+	// v1 = vertex 0, texcoord
+	// v2 = vertex 1, position
+	// v3 = vertex 1, texcoord
+
+	// x1 y1
+	setemitraw 0
+	mov o0, v0
+	mov o1, c9.wwww
+	mov o2, v1
+	emit
+
+	// x2 y1
+	setemitraw 1
+	mov o0.xzw, v2.xzw
+	mov o0.y, v0.y
+	mov o1, c9.wwww
+	mov o2.xzw, v3.xzw
+	mov o2.y, v1.y
+	emit
+
+	// x1 y2
+	setemitraw 2, prim
+	mov o0.xzw, v0.xzw
+	mov o0.y, v2.y
+	mov o1, c9.wwww
+	mov o2.xzw, v1.xzw
+	mov o2.y, v3.y
+	emit
+
+	// x2 y2
+	setemitraw 0, prim, inv
+	mov o0, v2
+	mov o1, c9.wwww
+	mov o2, v3
+	emit
+
+	end
+	nop
+// TODO: In aemstro.py, this label shows up too early!
+end_gmain:

--- a/data/grender_hard7.vsh
+++ b/data/grender_hard7.vsh
@@ -1,101 +1,86 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
-	.const c9, 0.0, 0.0, 0.0078125, 1.0
-	.const c10, 0.00004, 0.00004, 0.0, 0.0
- 	.const c11, 0.0077725, 0.00004, 0.0, 0.0
-	.const c12, 0.00004, 0.0077725, 0.0, 0.0
-	.const c13, 0.0077725, 0.0077725, 0.0, 0.0
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
-	.out o2, result.texcoord0, 0x3
- 
-; setup uniform map (not required)
-		
-	.gsh gmain, end_gmain
-	
-; INPUT
-; - VERTEX ATTRIBUTES -
-; v0: vertex (x, y, and optional z)
-; v1: texcoord
-; - UNIFORMS -
-; c0-c3: projection matrix
-; c4: texcoord scale
- 
-;code
-	gmain:
-		; turn two vertices into a rectangle
-		; setemit: vtxid, primemit, winding
-		
-		; v0 = vertex 0, position
-		; v1 = vertex 0, texcoord
-		
-		; x1 y1
-		setemit vtx0, false, false
-		mov o0, v0 (0x5)
-		mov o1, c9 (0x8)
-		mov r3, v1 (0x5)
-		add o2, c10, r3 (0x5)
-		emit
-		
-		; x2 y1
-		setemit vtx1, false, false
-		mov r3, c14 (0x5)
-		add o0, v0, r3 (0x5)
-		mov o1, c9 (0x8)
-		mov r3, v1 (0x5)
-		add o2, c11, r3 (0x5)
-		emit
-		
-		; x1 y2
-		setemit vtx2, true, false
-		mov r3, c15 (0x5)
-		add o0, v0, r3 (0x5)
-		mov o1, c9 (0x8)
-		mov r3, v1 (0x5)
-		add o2, c12, r3 (0x5)
-		emit
-		
-		; x2 y2
-		setemit vtx0, true, true
-		mov r4, c14 (0x5)
-		add r3, c15, r4 (0x5)
-		add o0, v0, r3 (0x5)
-		mov o1, c9 (0x8)
-		mov r3, v1 (0x5)
-		add o2, c13, r3 (0x5)
-		emit
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
 
-		
-		end
-		nop
-	end_gmain:
- 
-;operand descriptors
-	.opdesc x___, xyzw, xyzw ; 0x0
-	.opdesc _y__, xyzw, xyzw ; 0x1
-	.opdesc __z_, xyzw, xyzw ; 0x2
-	.opdesc ___w, xyzw, xyzw ; 0x3
-	.opdesc xyz_, xyzw, xyzw ; 0x4
-	.opdesc xyzw, xyzw, xyzw ; 0x5
-	.opdesc x_zw, xyzw, xyzw ; 0x6
-	.opdesc _y__, yyyw, xyzw ; 0x7
-	.opdesc xyzw, wwww, wwww ; 0x8
+// setup constants
+.alias const9  c9  as (0.0, 0.0, 0.0078125, 1.0)
+.alias const10 c10 as (0.00004, 0.00004, 0.0, 0.0)
+.alias const11 c11 as (0.0077725, 0.00004, 0.0, 0.0)
+.alias const12 c12 as (0.00004, 0.0077725, 0.0, 0.0)
+.alias const13 c13 as (0.0077725, 0.0077725, 0.0, 0.0)
+
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
+.alias resulttex0     o2.xy as texcoord0
+
+// setup uniform map (not required)
+
+// INPUT
+// - VERTEX ATTRIBUTES -
+// v0: vertex (x, y, and optional z)
+// v1: texcoord
+// - UNIFORMS -
+// c0-c3: projection matrix
+// c4: texcoord scale
+
+gmain:
+	// turn two vertices into a rectangle
+	// setemit: vtxid, primemit, winding
+
+	// v0 = vertex 0, position
+	// v1 = vertex 0, texcoord
+
+	// x1 y1
+	setemitraw 0
+	mov o0, v0
+	mov o1, c9.wwww
+	mov r3, v1
+	add o2, c10, r3
+	emit
+
+	// x2 y1
+	setemitraw 1
+	mov r3, c14
+	add o0, v0, r3
+	mov o1, c9.wwww
+	mov r3, v1
+	add o2, c11, r3
+	emit
+
+	// x1 y2
+	setemitraw 2, prim
+	mov r3, c15
+	add o0, v0, r3
+	mov o1, c9.wwww
+	mov r3, v1
+	add o2, c12, r3
+	emit
+
+	// x2 y2
+	setemitraw 0, prim, inv
+	mov r4, c14
+	add r3, c15, r4
+	add o0, v0, r3
+	mov o1, c9.wwww
+	mov r3, v1
+	add o2, c13, r3
+	emit
+
+	end
+	nop
+end_gmain:

--- a/data/grender_soft.vsh
+++ b/data/grender_soft.vsh
@@ -1,90 +1,81 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
-	.const c5, 0.0, 0.0, 0.00390625, 1.0
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
-	.out o2, result.texcoord0, 0x3
-	.out o3, result.texcoord1, 0x3
- 
-; setup uniform map (not required)
-	.uniform c0, c3, projMtx
-	
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
 
-	.gsh gmain, end_gmain
- 
-;code
-	gmain:
-		; turn two vertices into a rectangle
-		; setemit: vtxid, primemit, winding
-		
-		; v0 = vertex 0, position
-		; v1 = vertex 0, texcoord
-		; v2 = vertex 1, position
-		; v3 = vertex 1, texcoord
-		
-		; x1 y1
-		setemit vtx0, false, false
-		mov o0, v0 (0x0)
-		mov o1, c5 (0x3)
-		mov o2, v1 (0x0)
-		mov o3, v1 (0x0)
-		emit
-		
-		; x2 y1
-		setemit vtx1, false, false
-		mov o0, v2 (0x1)
-		mov o0, v0 (0x2)
-		mov o1, c5 (0x3)
-		mov o2, v3 (0x1)
-		mov o2, v1 (0x2)
-		mov o3, v3 (0x1)
-		mov o3, v1 (0x2)
-		emit
-		
-		; x1 y2
-		setemit vtx2, true, false
-		mov o0, v0 (0x1)
-		mov o0, v2 (0x2)
-		mov o1, c5 (0x3)
-		mov o2, v1 (0x1)
-		mov o2, v3 (0x2)
-		mov o3, v1 (0x1)
-		mov o3, v3 (0x2)
-		emit
-		
-		; x2 y2
-		setemit vtx0, true, true
-		mov o0, v2 (0x0)
-		mov o1, c5 (0x8)
-		mov o2, v3 (0x0)
-		mov o3, v3 (0x0)
-		emit
-		
-		end
-		nop
-	end_gmain:
- 
-;operand descriptors
-	.opdesc xyzw, xyzw, xyzw ; 0x0
-	.opdesc x_zw, xyzw, xyzw ; 0x1
-	.opdesc _y__, yyyw, xyzw ; 0x2
-	.opdesc xyzw, wwww, wwww ; 0x3
+// setup constants
+.alias myconst c5 as (0.0, 0.0, 0.00390625, 1.0)
+
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
+.alias resulttex0     o2.xy as texcoord0
+.alias resulttex1     o3.xy as texcoord1
+
+// setup uniform map (not required)
+.alias projMtx c0-c3
+
+gmain:
+	// turn two vertices into a rectangle
+	// setemit: vtxid, primemit, winding
+
+	// v0 = vertex 0, position
+	// v1 = vertex 0, texcoord
+	// v2 = vertex 1, position
+	// v3 = vertex 1, texcoord
+
+	// x1 y1
+	setemitraw 0
+	mov o0, v0
+	mov o1, c5.wwww
+	mov o2, v1
+	mov o3, v1
+	emit
+
+	// x2 y1
+	setemitraw 1
+	mov o0.xzw, v2.xzw
+	mov o0.y, v0.y
+	mov o1, c5.wwww
+	mov o2.xzw, v3.xzw
+	mov o2.y, v1.y
+	mov o3.xzw, v3.xzw
+	mov o3.y, v1.y
+	emit
+
+	// x1 y2
+	setemitraw 2, prim
+	mov o0.xzw, v0.xzw
+	mov o0.y, v2.y
+	mov o1, c5.wwww
+	mov o2.xzw, v1.xzw
+	mov o2.y, v3.y
+	mov o3.xzw, v1.xzw
+	mov o3.y, v3.y
+	emit
+
+	// x2 y2
+	setemitraw 0, prim, inv
+	mov o0, v2
+	//mov o1, c5 (0x8)
+	mov o1, c5 // TODO???
+	mov o2, v3
+	mov o3, v3
+	emit
+
+	end
+	nop
+end_gmain:

--- a/data/gwindow_mask.vsh
+++ b/data/gwindow_mask.vsh
@@ -1,80 +1,69 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
 
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
- 
-; setup uniform map (not required)
-	
+// setup constants
 
-	.gsh gmain, end_gmain
-	
-; input
-; v0: XY coordinates
-; v1: 'alpha' in X
- 
-;code
-	
-	gmain:
-		; turn two vertices into a rectangle
-		; setemit: vtxid, primemit, winding
-		
-		; v0 = vertex 0, position
-		; v1 = vertex 0, color
-		; v2 = vertex 1, position
-		; v3 = vertex 1, color
-		
-		; x1 y1
-		setemit vtx0, false, false
-		mov o0, v0 (0x0)
-		mov o1, v1 (0x0)
-		emit
-		
-		; x2 y1
-		setemit vtx1, false, false
-		mov o0, v2 (0x1)
-		mov o0, v0 (0x2)
-		mov o1, v3 (0x0)
-		emit
-		
-		; x1 y2
-		setemit vtx2, true, false
-		mov o0, v0 (0x1)
-		mov o0, v2 (0x2)
-		mov o1, v1 (0x0)
-		emit
-		
-		; x2 y2
-		setemit vtx0, true, true
-		mov o0, v2 (0x0)
-		mov o1, v3 (0x0)
-		emit
-		
-		end
-		nop
-	end_gmain:
- 
-;operand descriptors
-	.opdesc xyzw, xyzw, xyzw ; 0x0
-	.opdesc x_zw, xyzw, xyzw ; 0x1
-	.opdesc _y__, yyyw, xyzw ; 0x2
 
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
+
+// setup uniform map (not required)
+
+// input
+// v0: XY coordinates
+// v1: 'alpha' in X
+
+gmain:
+	// turn two vertices into a rectangle
+	// setemit: vtxid, primemit, winding
+
+	// v0 = vertex 0, position
+	// v1 = vertex 0, color
+	// v2 = vertex 1, position
+	// v3 = vertex 1, color
+
+	// x1 y1
+	setemitraw 0
+	mov o0, v0
+	mov o1, v1
+	emit
+
+	// x2 y1
+	setemitraw 1
+	mov o0.xzw, v2.xzw
+	mov o0.y, v0.y
+	mov o1, v3
+	emit
+
+	// x1 y2
+	setemitraw 2, prim
+	mov o0.xzw, v0.xzw
+	mov o0.y, v2.y
+	mov o1, v1
+	emit
+
+	// x2 y2
+	setemitraw 0, prim, inv
+	mov o0, v2
+	mov o1, v3
+	emit
+
+	end
+	nop
+end_gmain:

--- a/data/vfinal.vsh
+++ b/data/vfinal.vsh
@@ -1,52 +1,46 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
-	.const c5, 0.0, 0.0, 0.0, 1.0
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
- 
-; setup uniform map (not required)
-	.uniform c0, c3, projMtx
-	
-	.vsh vmain, end_vmain
- 
-;code
-	vmain:
-		mov r1, v0 (0x4)
-		mov r1, c5 (0x3)
-		; result.pos = projMtx * in.pos
-		dp4 o0, c0, r1 (0x0)
-		dp4 o0, c1, r1 (0x1)
-		dp4 o0, c2, r1 (0x2)
-		dp4 o0, c3, r1 (0x3)
-		; result.texcoord = in.texcoord
-		mov o1, v1 (0x5)
-		end
-		nop
-	end_vmain:
-	 
-;operand descriptors
-	.opdesc x___, xyzw, xyzw ; 0x0
-	.opdesc _y__, xyzw, xyzw ; 0x1
-	.opdesc __z_, xyzw, xyzw ; 0x2
-	.opdesc ___w, xyzw, xyzw ; 0x3
-	.opdesc xyz_, xyzw, xyzw ; 0x4
-	.opdesc xyzw, xyzw, xyzw ; 0x5
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
+
+// setup constants
+.alias myconst c5 as (0.0, 0.0, 0.0, 1.0)
+
+// setup outmap
+// TODO: Changing these to result.position/result.color breaks stuff!
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
+
+// setup uniform map (not required)
+.alias projMtx c0-c3
+
+vmain:
+	mov r1.xyz, v0.xyz
+	mov r1.w, myconst.w
+
+    // TODO: ; as the start of a comment doesn't cause an error?!
+
+	// result.pos = projMtx * in.pos
+	dp4 o0.x, projMtx[0].xyzw, r1.xyzw
+	dp4 o0.y, projMtx[1].xyzw, r1.xyzw
+	dp4 o0.z, projMtx[2].xyzw, r1.xyzw
+	dp4 o0.w, projMtx[3].xyzw, r1.xyzw
+
+	// result.texcoord = in.texcoord
+	mov o1.xyzw, v1.xyzw
+	end
+	nop
+end_vmain:

--- a/data/vplain_quad.vsh
+++ b/data/vplain_quad.vsh
@@ -1,58 +1,47 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
-	.const c5, 0.0, 0.0, 0.00390625, 1.0
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
- 
-; setup uniform map (not required)
-	.uniform c0, c3, projMtx
-	
-	.vsh vmain, end_vmain
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
 
-	
-; input
-; v0: XYZ coordinates
-; v1: color
- 
-;code
-	vmain:
-		mov r1, v0 (0x4)
-		mov r1, c5 (0x3)
-		; result.pos = projMtx * in.pos
-		dp4 o0, c0, r1 (0x0)
-		dp4 o0, c1, r1 (0x1)
-		dp4 o0, c2, r1 (0x2)
-		dp4 o0, c3, r1 (0x3)
-		; result.color = in.color
-		mul o1, c5, v1 (0x5)
-		end
-		nop
-	end_vmain:
-	
- 
-;operand descriptors
-	.opdesc x___, xyzw, xyzw ; 0x0
-	.opdesc _y__, xyzw, xyzw ; 0x1
-	.opdesc __z_, xyzw, xyzw ; 0x2
-	.opdesc ___w, xyzw, xyzw ; 0x3
-	.opdesc xyz_, xyzw, xyzw ; 0x4
-	.opdesc xyzw, zzzz, xyzw ; 0x5
+// setup constants
+.alias myconst c5 as (0.0, 0.0, 0.00390625, 1.0)
+
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
+
+// setup uniform map (not required)
+.alias projMtx c0-c3
+
+// input
+// v0: XYZ coordinates
+// v1: color
+
+vmain:
+	mov r1.xyz, v0.xyz
+	mov r1.w, c5.w
+
+	// result.pos = projMtx * in.pos
+	dp4 o0.x, projMtx[0], r1
+	dp4 o0.y, projMtx[1], r1
+	dp4 o0.z, projMtx[2], r1
+	dp4 o0.w, projMtx[3].xyzw, r1.xyzw
+
+	// result.color = in.color
+	mul o1, myconst.zzzz, v1
+	end
+	nop
+end_vmain:

--- a/data/vrender_hard.vsh
+++ b/data/vrender_hard.vsh
@@ -1,66 +1,52 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
-	.const c9, 0.0, 0.0, 0.0078125, 1.0
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
 
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
+// setup constants
+.alias myconst c9 as (0.0, 0.0, 0.0078125, 1.0)
 
- 
-; setup uniform map (not required)
-	.uniform c0, c3, projMtx
-		
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
 
-	.vsh vmain, end_vmain
-	
-; INPUT
-; - VERTEX ATTRIBUTES -
-; v0: vertex (x, y, and optional z)
-; v1: texcoord
-; - UNIFORMS -
-; c0-c3: projection matrix
-; c4: texcoord scale
- 
-;code
-	vmain:
-		mov r1, v0 (0x4)
-		mov r1, c9 (0x3)
-		
-		; result.pos = projMtx * temp.pos
-		dp4 o0, c0, r1 (0x0)
-		dp4 o0, c1, r1 (0x1)
-		dp4 o0, c2, r1 (0x2)
-		dp4 o0, c3, r1 (0x3)
+// setup uniform map (not required)
+.alias projMtx c0-c3
 
-		; result.texcoord = in.texcoord * (uniform scale in c4)
-		mul r1, c4, v1 (0x5)
-		mov o1, r1 (0x5)
-		end
-		nop
-	end_vmain:
-	 
-;operand descriptors
-	.opdesc x___, xyzw, xyzw ; 0x0
-	.opdesc _y__, xyzw, xyzw ; 0x1
-	.opdesc __z_, xyzw, xyzw ; 0x2
-	.opdesc ___w, xyzw, xyzw ; 0x3
-	.opdesc xyz_, xyzw, xyzw ; 0x4
-	.opdesc xyzw, xyzw, xyzw ; 0x5
+// INPUT
+// - VERTEX ATTRIBUTES -
+// v0: vertex (x, y, and optional z)
+// v1: texcoord
+// - UNIFORMS -
+// c0-c3: projection matrix
+// c4: texcoord scale
+
+vmain:
+	mov r1.xyz, v0.xyz
+	mov r1.w, c9.w
+
+	// result.pos = projMtx * temp.pos
+	dp4 o0.x, projMtx[0], r1
+	dp4 o0.y, projMtx[1], r1
+	dp4 o0.z, projMtx[2], r1
+	dp4 o0.w, projMtx[3], r1
+
+	// result.texcoord = in.texcoord * (uniform scale in c4)
+	mul r1, c4, v1
+	mov o1, r1
+	end
+	nop
+end_vmain:

--- a/data/vrender_hard7.vsh
+++ b/data/vrender_hard7.vsh
@@ -1,71 +1,58 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
-	.const c9, 0.0, 0.0, 0.0078125, 1.0
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
 
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
+// setup constants
+.alias myconst c9 as (0.0, 0.0, 0.0078125, 1.0)
 
- 
-; setup uniform map (not required)
-	.uniform c0, c3, projMtx
-	.uniform c5, c8, m7Mtx		
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
 
-	.vsh vmain, end_vmain
-	
-; INPUT
-; - VERTEX ATTRIBUTES -
-; v0: vertex (x, y, and optional z)
-; v1: texcoord
-; - UNIFORMS -
-; c0-c3: projection matrix
-; c4: texcoord scale
- 
-;code
-	vmain:
-		mov r2, v0 (0x4)
-		mov r2, c9 (0x3)
+// setup uniform map (not required)
+.alias projMtx c0-c3
+.alias m7Mtx c5-c8
 
-		dp4 r1, c5, r2 (0x0)
-		dp4 r1, c6, r2 (0x1)
-		dp4 r1, c7, r2 (0x2)
-		dp4 r1, c8, r2 (0x3)
-		
-		; result.pos = projMtx * temp.pos
-		dp4 o0, c0, r1 (0x0)
-		dp4 o0, c1, r1 (0x1)
-		dp4 o0, c2, r1 (0x2)
-		dp4 o0, c3, r1 (0x3)
+// INPUT
+// - VERTEX ATTRIBUTES -
+// v0: vertex (x, y, and optional z)
+// v1: texcoord
+// - UNIFORMS -
+// c0-c3: projection matrix
+// c4: texcoord scale
 
-		; result.texcoord = in.texcoord * (uniform scale in c4)
-		mul r1, c4, v1 (0x5)
-		mov o1, r1 (0x5)
-		end
-		nop
-	end_vmain:
-	 
-;operand descriptors
-	.opdesc x___, xyzw, xyzw ; 0x0
-	.opdesc _y__, xyzw, xyzw ; 0x1
-	.opdesc __z_, xyzw, xyzw ; 0x2
-	.opdesc ___w, xyzw, xyzw ; 0x3
-	.opdesc xyz_, xyzw, xyzw ; 0x4
-	.opdesc xyzw, xyzw, xyzw ; 0x5
+vmain:
+	mov r2.xyz, v0.xyz
+	mov r2.w, c9.w
+
+	dp4 r1.x, m7Mtx[0], r2
+	dp4 r1.y, m7Mtx[1], r2
+	dp4 r1.z, m7Mtx[2], r2
+	dp4 r1.w, m7Mtx[3], r2
+
+	// result.pos = projMtx * temp.pos
+	dp4 o0.x, projMtx[0], r1
+	dp4 o0.y, projMtx[1], r1
+	dp4 o0.z, projMtx[2], r1
+	dp4 o0.w, projMtx[3], r1
+
+	// result.texcoord = in.texcoord * (uniform scale in c4)
+	mul r1, c4, v1
+	mov o1, r1
+	end
+	nop
+end_vmain:

--- a/data/vrender_soft.vsh
+++ b/data/vrender_soft.vsh
@@ -1,54 +1,43 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
-	.const c5, 0.0, 0.0, 0.00390625, 1.0
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
- 
-; setup uniform map (not required)
-	.uniform c0, c3, projMtx
-	
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
 
-	.vsh vmain, end_vmain
+// setup constants
+.alias myconst c5 as (0.0, 0.0, 0.00390625, 1.0)
 
- 
-;code
-	vmain:
-		mov r1, v0 (0x4)
-		mov r1, c5 (0x3)
-		; result.pos = projMtx * in.pos
-		dp4 o0, c0, r1 (0x0)
-		dp4 o0, c1, r1 (0x1)
-		dp4 o0, c2, r1 (0x2)
-		dp4 o0, c3, r1 (0x3)
-		; result.texcoord = in.texcoord * (1/256)
-		mul o1, c5, v1 (0x5)	; multiply s/t, multiply r/q by 1
-		end
-		nop
-	end_vmain:
-	 
-;operand descriptors
-	.opdesc x___, xyzw, xyzw ; 0x0
-	.opdesc _y__, xyzw, xyzw ; 0x1
-	.opdesc __z_, xyzw, xyzw ; 0x2
-	.opdesc ___w, xyzw, xyzw ; 0x3
-	.opdesc xyz_, xyzw, xyzw ; 0x4
-	.opdesc xyzw, zzww, xyzw ; 0x5
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
+
+// setup uniform map (not required)
+.alias projMtx c0-c3
+
+vmain:
+	mov r1.xyz, v0.xyz
+	mov r1.w, c5.w
+
+	// result.pos = projMtx * in.pos
+	dp4 o0.x, projMtx[0], r1
+	dp4 o0.y, projMtx[1], r1
+	dp4 o0.z, projMtx[2], r1
+	dp4 o0.w, projMtx[3], r1
+
+	// result.texcoord = in.texcoord * (1/256)
+	mul o1, c5.zzww, v1   // multiply s/t, multiply r/q by 1
+	end
+	nop
+end_vmain:

--- a/data/vwindow_mask.vsh
+++ b/data/vwindow_mask.vsh
@@ -1,59 +1,47 @@
-; -----------------------------------------------------------------------------
-; Copyright 2014 StapleButter
-;
-; This file is part of blargSnes.
-;
-; blargSnes is free software: you can redistribute it and/or modify it under
-; the terms of the GNU General Public License as published by the Free
-; Software Foundation, either version 3 of the License, or (at your option)
-; any later version.
-;
-; blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
-; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
-; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-;
-; You should have received a copy of the GNU General Public License along 
-; with blargSnes. If not, see http://www.gnu.org/licenses/.
-; -----------------------------------------------------------------------------
- 
-; setup constants
-	.const c5, 0.0, 0.0, 0.00390625, 1.0
+// -----------------------------------------------------------------------------
+// Copyright 2014 StapleButter
+//
+// This file is part of blargSnes.
+//
+// blargSnes is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with blargSnes. If not, see http://www.gnu.org/licenses/.
+// -----------------------------------------------------------------------------
 
- 
-; setup outmap
-	.out o0, result.position, 0xF
-	.out o1, result.color, 0xF
- 
-; setup uniform map (not required)
-	.uniform c0, c3, projMtx
-	
+// setup constants
+.alias myconst c5 as (0.0, 0.0, 0.00390625, 1.0)
 
-	.vsh vmain, end_vmain
+// setup outmap
+.alias resultposition o0 as position
+.alias resultcolor    o1 as color
 
-	
-; input
-; v0: XY coordinates
-; v1: 'alpha' in X
- 
-;code
-	vmain:
-		mov r1, v0 (0x4)
-		mov r1, c5 (0x3)
-		; result.pos = projMtx * in.pos
-		dp4 o0, c0, r1 (0x0)
-		dp4 o0, c1, r1 (0x1)
-		dp4 o0, c2, r1 (0x2)
-		dp4 o0, c3, r1 (0x3)
-		; result.color = in.color
-		mul o1, c5, v1 (0x5)
-		end
-		nop
-	end_vmain:
-	 
-;operand descriptors
-	.opdesc x___, xyzw, xyzw ; 0x0
-	.opdesc _y__, xyzw, xyzw ; 0x1
-	.opdesc __z_, xyzw, xyzw ; 0x2
-	.opdesc ___w, xyzw, xyzw ; 0x3
-	.opdesc xyz_, xyzw, xyzw ; 0x4
-	.opdesc xyzw, zzzz, xxxx ; 0x5
+// setup uniform map (not required)
+.alias projMtx c0-c3
+
+// input
+// v0: XY coordinates
+// v1: 'alpha' in X
+
+vmain:
+	mov r1.xyz, v0.xyz
+	mov r1.w, c5.w
+
+	// result.pos = projMtx * in.pos
+	dp4 o0.x, projMtx[0], r1
+	dp4 o0.y, projMtx[1], r1
+	dp4 o0.z, projMtx[2], r1
+	dp4 o0.w, projMtx[3], r1
+
+	// result.color = in.color
+	mul o1, c5.zzzz, v1.xxxx
+	end
+	nop
+end_vmain:

--- a/source/main.c
+++ b/source/main.c
@@ -887,12 +887,12 @@ int main()
 	vplainQuadShader = DVLB_ParseFile((u32*)vplain_quad_vsh_shbin, vplain_quad_vsh_shbin_size);		gplainQuadShader = DVLB_ParseFile((u32*)gplain_quad_vsh_shbin, gplain_quad_vsh_shbin_size);
 	vwindowMaskShader = DVLB_ParseFile((u32*)vwindow_mask_vsh_shbin, vwindow_mask_vsh_shbin_size);	gwindowMaskShader = DVLB_ParseFile((u32*)gwindow_mask_vsh_shbin, gwindow_mask_vsh_shbin_size);
 
-	shaderProgramInit(&finalShaderP);		shaderProgramSetVsh(&finalShaderP, &vfinalShader->DVLE[0]);				shaderProgramSetGsh(&finalShaderP, &gfinalShader->DVLE[1], 4);
-	shaderProgramInit(&softRenderShaderP);	shaderProgramSetVsh(&softRenderShaderP, &vsoftRenderShader->DVLE[0]);	shaderProgramSetGsh(&softRenderShaderP, &gsoftRenderShader->DVLE[1], 4);
-	shaderProgramInit(&hardRenderShaderP);	shaderProgramSetVsh(&hardRenderShaderP, &vhardRenderShader->DVLE[0]);	shaderProgramSetGsh(&hardRenderShaderP, &ghardRenderShader->DVLE[1], 4);
-	shaderProgramInit(&hard7RenderShaderP);	shaderProgramSetVsh(&hard7RenderShaderP, &vhard7RenderShader->DVLE[0]);	shaderProgramSetGsh(&hard7RenderShaderP, &ghard7RenderShader->DVLE[1], 2);
-	shaderProgramInit(&plainQuadShaderP);	shaderProgramSetVsh(&plainQuadShaderP, &vplainQuadShader->DVLE[0]);		shaderProgramSetGsh(&plainQuadShaderP, &gplainQuadShader->DVLE[1], 4);
-	shaderProgramInit(&windowMaskShaderP);	shaderProgramSetVsh(&windowMaskShaderP, &vwindowMaskShader->DVLE[0]);	shaderProgramSetGsh(&windowMaskShaderP, &gwindowMaskShader->DVLE[1], 4);
+	shaderProgramInit(&finalShaderP);		shaderProgramSetVsh(&finalShaderP, &vfinalShader->DVLE[0]);				shaderProgramSetGsh(&finalShaderP, &gfinalShader->DVLE[0], 4);
+	shaderProgramInit(&softRenderShaderP);	shaderProgramSetVsh(&softRenderShaderP, &vsoftRenderShader->DVLE[0]);	shaderProgramSetGsh(&softRenderShaderP, &gsoftRenderShader->DVLE[0], 4);
+	shaderProgramInit(&hardRenderShaderP);	shaderProgramSetVsh(&hardRenderShaderP, &vhardRenderShader->DVLE[0]);	shaderProgramSetGsh(&hardRenderShaderP, &ghardRenderShader->DVLE[0], 4);
+	shaderProgramInit(&hard7RenderShaderP);	shaderProgramSetVsh(&hard7RenderShaderP, &vhard7RenderShader->DVLE[0]);	shaderProgramSetGsh(&hard7RenderShaderP, &ghard7RenderShader->DVLE[0], 2);
+	shaderProgramInit(&plainQuadShaderP);	shaderProgramSetVsh(&plainQuadShaderP, &vplainQuadShader->DVLE[0]);		shaderProgramSetGsh(&plainQuadShaderP, &gplainQuadShader->DVLE[0], 4);
+	shaderProgramInit(&windowMaskShaderP);	shaderProgramSetVsh(&windowMaskShaderP, &vwindowMaskShader->DVLE[0]);	shaderProgramSetGsh(&windowMaskShaderP, &gwindowMaskShader->DVLE[0], 4);
 
 	GX_SetMemoryFill(NULL, gpuOut, 0x404040FF, &gpuOut[0x2EE00], 0x201, gpuDOut, 0x00000000, &gpuDOut[0x2EE00], 0x201);
 	gspWaitForPSC0();


### PR DESCRIPTION
Drops aemstro usage in favor of nihstro. I didn't bother introducing variable names instead of hardcoded register indices in the shader source (too much work :p), but even without that nihstro syntax the shaders should be a lot easier to read now.

I'm not entirely sure what to put in the Makefile to make sure it works on all operating systems. Maybe it actually already does everywhere. I only tested it on Linux, though (the generated shaders worked fine on hardware).

NOTE: Tested with neobrain/nihstro@9cd74e39195 .