### PR TITLE
[veryhard] Compilation warnings fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ INCLUDES	:=	include
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard
 
-CFLAGS	:=	-g -Wall -O2 -mword-relocations -ffunction-sections \
+CFLAGS	:=	-g -Wall -O2 -fno-strict-aliasing -mword-relocations -ffunction-sections \
 			-fomit-frame-pointer -ffast-math \
 			$(ARCH)
 

--- a/source/config.c
+++ b/source/config.c
@@ -39,7 +39,7 @@ const char* configFileS =
 	"ScaleMode=%d\n"
 	"DirPath=%s\n";
 
-char * lastDir[0x106];
+char lastDir[0x106];
 
 
 void LoadConfig(u8 init)

--- a/source/config.c
+++ b/source/config.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <3ds.h>
 
-#include "main.h"
+#include "ui_console.h"
 #include "config.h"
 
 Config_t Config;

--- a/source/cpu.h
+++ b/source/cpu.h
@@ -61,6 +61,7 @@ extern CPU_Regs_t CPU_Regs;
 	
 void CPU_Reset();
 void CPU_Run();
+void CPU_MainLoop();
 
 void CPU_TriggerIRQ();
 void CPU_TriggerNMI();

--- a/source/dsp.c
+++ b/source/dsp.c
@@ -3,7 +3,7 @@
 
 #include <string.h>
 
-#include "main.h"
+#include "ui_console.h"
 #include "dsp.h"
 
 

--- a/source/main.c
+++ b/source/main.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <3ds.h>
 
-#include "main.h"
+#include "ui_console.h"
 #include "config.h"
 
 #include "blargGL.h"

--- a/source/main.c
+++ b/source/main.c
@@ -132,8 +132,8 @@ void reportStats()
 		reportFrame++;
 		if(reportFrame == 60)
 		{
-			bprintf("%d\n", vramSpaceFree());
-			bprintf("E: %.2f, P: %.2f, G: %.2f, FPS: %02d\n", ((double)(emuTime / 60) / 4468724.0) * 100, ((double)(ppuTime / 60) / 4468724.0) * 100, ((double)(gpuTime / gpuFPS) / 4468724.0) * 100, gpuFPS);
+			bprintf("%lu\n", vramSpaceFree());
+			bprintf("E: %.2f, P: %.2f, G: %.2f, FPS: %02lu\n", ((double)(emuTime / 60) / 4468724.0) * 100, ((double)(ppuTime / 60) / 4468724.0) * 100, ((double)(gpuTime / gpuFPS) / 4468724.0) * 100, gpuFPS);
 			bprintf(" \n");
 			reportFrame = 0;
 			emuTime = 0;
@@ -203,7 +203,7 @@ void dbg_save(char* path, void* buf, int size)
 
 void debugcrapo(u32 op, u32 op2)
 {
-	bprintf("DBG: %08X %08X\n", op, op2);
+	bprintf("DBG: %08lX %08lX\n", op, op2);
 	DrawConsole();
 	//SwapBottomBuffers(0);
 	//ClearBottomBuffer();
@@ -214,7 +214,7 @@ void SPC_ReportUnk(u8 op, u32 pc)
 	static bool unkreported = false;
 	if (unkreported) return;
 	unkreported = true;
- 	bprintf("SPC UNK %02X @ %04X\n", op, pc);
+ 	bprintf("SPC UNK %02X @ %04lX\n", op, pc);
  }	
 
 void ReportCrash()
@@ -226,9 +226,9 @@ void ReportCrash()
 	bprintf("Game has crashed (STOP)\n");
 	
 	extern u32 debugpc;
-	bprintf("PC: %02X:%04X (%06X)\n", CPU_Regs.PBR, CPU_Regs.PC, debugpc);
+	bprintf("PC: %02X:%04X (%06lX)\n", CPU_Regs.PBR, CPU_Regs.PC, debugpc);
 	bprintf("P: %02X | M=%d X=%d E=%d\n", CPU_Regs.P.val&0xFF, CPU_Regs.P.M, CPU_Regs.P.X, CPU_Regs.P.E);
-	bprintf("A: %04X X: %04X Y: %04X\n", CPU_Regs.A, CPU_Regs.X, CPU_Regs.Y);
+	bprintf("A: %04lX X: %04lX Y: %04lX\n", CPU_Regs.A, CPU_Regs.X, CPU_Regs.Y);
 	bprintf("S: %04X D: %02X DBR: %02X\n", CPU_Regs.S, CPU_Regs.D, CPU_Regs.DBR);
 	
 	bprintf("Stack\n");
@@ -260,7 +260,7 @@ void ReportCrash()
 	
 	u32 pc = (CPU_Regs.PBR<<16)|CPU_Regs.PC;
 	u32 ptr = Mem_PtrTable[pc >> 13];
-	bprintf("Ptr table entry: %08X\n", ptr);
+	bprintf("Ptr table entry: %08lX\n", ptr);
 	
 	bprintf("Tell StapleButter\n");
 	
@@ -796,7 +796,7 @@ void reportshit(u32 pc, u32 a, u32 y)
 	//bprintf("TSX S=%04X X=%04X P=%04X  %04X\n", pc>>16, a, y&0xFFFF, y>>16);
 	if (reported) return;
 	//bprintf("!! %08X -> %08X | %08X\n", pc, a, y);
-	bprintf("!! A=%02X X=%02X Y=%02X\n", pc, a, y);
+	bprintf("!! A=%02lX X=%02lX Y=%02lX\n", pc, a, y);
 	reported=1;
 	//running=0; pause=1;
 }
@@ -806,7 +806,7 @@ void reportshit2(u32 pc, u32 a, u32 y)
 {
 	//bprintf("TSC S=%04X A=%04X P=%04X  %04X\n", pc>>16, a, y&0xFFFF, y>>16);
 	if (SNES_SysRAM[0x3C8] == 0 && reported2 != 0)
-		bprintf("[%06X] 3C8=0\n", debugpc);
+		bprintf("[%06lX] 3C8=0\n", debugpc);
 	reported2 = SNES_SysRAM[0x3C8];
 }
 

--- a/source/main.c
+++ b/source/main.c
@@ -728,7 +728,7 @@ bool StartROM(char* path, char* dir)
 	{
 		exitspc = 1; pause = 1;
 		svcSignalEvent(SPCSync);
-		svcWaitSynchronization(spcthread, U64_MAX);
+		svcWaitSynchronization(threadGetHandle(spcthread), U64_MAX);
 		threadJoin(spcthread, U64_MAX);
 		exitspc = 0;
 	}
@@ -1112,7 +1112,7 @@ int main()
 	svcSignalEvent(SPCSync);
 	if (spcthread) 
 	{
-		svcWaitSynchronization(spcthread, U64_MAX);
+		svcWaitSynchronization(threadGetHandle(spcthread), U64_MAX);
 		threadJoin(spcthread, U64_MAX);
 	}
 	svcCloseHandle(SPCSync);

--- a/source/main.c
+++ b/source/main.c
@@ -159,7 +159,6 @@ void SPCThread(void *arg)
 	u32 lastpos = 0;
 
 
-	int i;
 	while (!exitspc)
 	{
 		svcWaitSynchronization(SPCSync, U64_MAX);
@@ -724,7 +723,6 @@ bool StartROM(char* path, char* dir)
 {
 	
 	char temppath[0x210];
-	Result res;
 	
 	if (spcthread)
 	{
@@ -1053,7 +1051,7 @@ int main()
 					{
 						u32 timestamp = (u32)(svcGetSystemTick() / 446872);
 						char file[256];
-						snprintf(file, 256, "/blargSnes%08d.bmp", timestamp);
+						snprintf(file, 256, "/blargSnes%08lu.bmp", timestamp);
 						if (TakeScreenshot(file))
 						{
 							bprintf("Screenshot saved as:\n");

--- a/source/main.h
+++ b/source/main.h
@@ -20,6 +20,6 @@
 #define MAIN_H
 
 void ClearConsole();
-void bprintf(char* fmt, ...);
+void bprintf(char* fmt, ...)  __attribute__((format(printf, 1, 2)));
 
 #endif

--- a/source/main.h
+++ b/source/main.h
@@ -19,7 +19,13 @@
 #ifndef MAIN_H
 #define MAIN_H
 
+void DrawConsole();
 void ClearConsole();
 void bprintf(char* fmt, ...)  __attribute__((format(printf, 1, 2)));
+
+void ContinueRendering();
+void FinishRendering();
+void RenderTopScreen();
+void ApplyScaling();
 
 #endif

--- a/source/mem.c
+++ b/source/mem.c
@@ -17,6 +17,8 @@
 */
 
 #include <stdlib.h>
+#include <string.h>
+#include <malloc.h>
 #include <3ds/types.h>
 #include <3ds/svc.h>
 

--- a/source/ppu.c
+++ b/source/ppu.c
@@ -803,7 +803,7 @@ void PPU_Write8(u32 addr, u8 val)
 			break;
 			
 		case 0x2B:
-			if(PPU.WinCombine[1] != val & 0xF)
+			if((PPU.WinCombine[1] != val) & 0xF)
 			{
 				PPU.WinCombine[1] = val & 0xF;
 				PPU.OBJWindowCombine = PPU_WindowCombine[(val & 0x03)];
@@ -906,7 +906,7 @@ void PPU_Write8(u32 addr, u8 val)
 				SPC_IOPorts[addr&0x03] = val;
 			}
 			else
-				iprintf("PPU_Write8(%08X, %08X)\n", addr, val);
+				iprintf("PPU_Write8(%08lX, %08X)\n", addr, val);
 			break;
 	}
 }
@@ -1186,7 +1186,6 @@ void PPU_VBlank()
 {
 	emuTime += svcGetSystemTick() - emuTick;
 
-	int i;
 	FinishRendering();
 	
 	if (!SkipThisFrame)

--- a/source/ppu.c
+++ b/source/ppu.c
@@ -17,10 +17,12 @@
 */
 
 #include <3ds.h>
+#include <string.h>
 
 #include "config.h"
 #include "snes.h"
 #include "ppu.h"
+#include "main.h"
 
 
 u32 Mem_WRAMAddr = 0;

--- a/source/ppu.c
+++ b/source/ppu.c
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "snes.h"
 #include "ppu.h"
+#include "ui_console.h"
 #include "main.h"
 #include "spc700.h"
 

--- a/source/ppu.c
+++ b/source/ppu.c
@@ -23,6 +23,7 @@
 #include "snes.h"
 #include "ppu.h"
 #include "main.h"
+#include "spc700.h"
 
 
 u32 Mem_WRAMAddr = 0;

--- a/source/ppu.c
+++ b/source/ppu.c
@@ -490,7 +490,7 @@ u8 PPU_Read8(u32 addr)
 				ret = SPC_IOPorts[4 + (addr&0x03)];
 			}
 			else
-				bprintf("Open bus 21%02X\n", addr); 
+				bprintf("Open bus 21%02lX\n", addr); 
 			break;
 	}
 
@@ -939,7 +939,7 @@ void PPU_Write16(u32 addr, u16 val)
 		case 0x42: SPC_Compensate(); *(u16*)&SPC_IOPorts[2] = val; break;
 		
 		case 0x3F:
-		case 0x43: bprintf("!! write $21%02X %04X\n", addr, val); break;
+		case 0x43: bprintf("!! write $21%02lX %04X\n", addr, val); break;
 		
 		case 0x81: Mem_WRAMAddr = (Mem_WRAMAddr & 0x00010000) | val; break;
 		

--- a/source/ppu.c
+++ b/source/ppu.c
@@ -39,7 +39,7 @@ extern u64 ppuTick;
 extern u64 ppuTime;
 
 
-const u8 PPU_OBJWidths[16] = 
+u8 PPU_OBJWidths[16] = 
 {
 	8, 16,
 	8, 32,
@@ -50,7 +50,8 @@ const u8 PPU_OBJWidths[16] =
 	16, 32,
 	16, 32
 };
-const u8 PPU_OBJHeights[16] = 
+
+u8 PPU_OBJHeights[16] = 
 {
 	8, 16,
 	8, 32,
@@ -81,7 +82,7 @@ const u8 PPU_OBJHeights[16] =
 // E 11:10 == outside, all disabled
 // F 11:11 == outside, all disabled
 
-const u16 PPU_WindowCombine[] = 
+u16 PPU_WindowCombine[] = 
 {
 	/* OR
 	1 1 1 1
@@ -361,6 +362,7 @@ u32 PPU_TranslateVRAMAddress(u32 addr)
 				  ((addr & 0x00700) >> 7) |
 				  ((addr & 0x000FE) << 3);
 	}
+	return 0x0;
 }
 
 

--- a/source/ppu.h
+++ b/source/ppu.h
@@ -422,6 +422,8 @@ void PPU_SwitchRenderers();
 void PPU_Reset();
 void PPU_DeInit();
 
+void PPU_ComputeWindows(PPU_WindowSegment *s);
+
 void PPU_SetColor(u32 num, u16 val);
 
 void PPU_LatchHVCounters();
@@ -434,6 +436,7 @@ void PPU_Write16(u32 addr, u16 val);
 void PPU_RenderScanline(u32 line);
 void PPU_VBlank();
 
+u32 PPU_TranslateVRAMAddress(u32 addr);
 
 void PPU_Init_Soft();
 void PPU_DeInit_Soft();
@@ -441,6 +444,11 @@ void PPU_DeInit_Soft();
 void PPU_RenderScanline_Soft(u32 line);
 void PPU_VBlank_Soft();
 
+void PPU_ConvertVRAM8(u32 addr, u8 val);
+void PPU_ConvertVRAM16(u32 addr, u16 val);
+void PPU_ConvertVRAMAll();
+
+void PPU_BlendScreens(u32 colorformat);
 
 void PPU_Init_Hard();
 void PPU_DeInit_Hard();

--- a/source/ppu_hard.c
+++ b/source/ppu_hard.c
@@ -24,7 +24,7 @@
 #include "mem.h"
 #include "snes.h"
 #include "ppu.h"
-
+#include "main.h"
 #include "config.h"
 
 

--- a/source/ppu_hard.c
+++ b/source/ppu_hard.c
@@ -943,19 +943,19 @@ void PPU_HardRenderBG_8x8(u32 setalpha, u32 num, int type, u32 pal, u32 prio, in
 		yoff = (s->YScroll + systart) >> yshift;
 		ntiles = 0;
 
+		o = &obg->Sections[0];
+		oxoff = o->XScroll & 0xF8;
+		oyoff = o->YScroll >> yshift;
+		tilemapx = PPU.VRAM + o->TilemapOffset + ((oyoff & 0xF8) << 3);
+		tilemapy = PPU.VRAM + o->TilemapOffset + (((oyoff + 8) & 0xF8) << 3);
 		if(opt)
 		{
-			o = &obg->Sections[0];
 			oyend = o->EndOffset;
 			while(systart >= oyend)
 			{
 				o++;
 				oyend = o->EndOffset;
 			}
-			oxoff = o->XScroll & 0xF8;
-			oyoff = o->YScroll >> yshift;
-			tilemapx = PPU.VRAM + o->TilemapOffset + ((oyoff & 0xF8) << 3);
-			tilemapy = PPU.VRAM + o->TilemapOffset + (((oyoff + 8) & 0xF8) << 3);
 			if (oyoff & 0x100) if (o->Size & 0x2) tilemapx += (o->Size & 0x1) ? 2048 : 1024;
 			if ((oyoff+8) & 0x100) if (o->Size & 0x2) tilemapy += (o->Size & 0x1) ? 2048 : 1024;
 			syend1 = syend + (hi && PPU.Interlace ? 3 : 7);
@@ -1517,7 +1517,7 @@ void PPU_HardRenderBG_Mode7(u32 setalpha, u32 num, int ystart, int yend, u32 pri
 	if(!prio)
 	{
 		found->vertexLen = nlines;
-		vptr = (u16*)((((u32)vptr) + 0x1F) & ~0x1F);
+		vptr = (float *)((((u32)vptr) + 0x1F) & ~0x1F);
 		vertexPtr = vptr;
 	}
 
@@ -2552,7 +2552,7 @@ void PPU_VBlank_Hard(int endLine)
 {
 	int i;
 
-	GX_MemoryFill(PPU_LayerGroup, 0x0000, &PPU_LayerGroup[256*256*4], GX_FILL_TRIGGER | GX_FILL_16BIT_DEPTH, &PPU_LayerGroup[256*256*4], 0x0000, &PPU_LayerGroup[256*256*8], GX_FILL_TRIGGER | GX_FILL_16BIT_DEPTH);
+	GX_MemoryFill((u32 *)PPU_LayerGroup, 0x0000, (u32 *)&PPU_LayerGroup[256*256*4], GX_FILL_TRIGGER | GX_FILL_16BIT_DEPTH, (u32 *)&PPU_LayerGroup[256*256*4], 0x0000, (u32 *)&PPU_LayerGroup[256*256*8], GX_FILL_TRIGGER | GX_FILL_16BIT_DEPTH);
 
 	PPU.CurModeSection->EndOffset = endLine;
 	

--- a/source/ppu_hard.c
+++ b/source/ppu_hard.c
@@ -2125,7 +2125,7 @@ void PPU_RenderScanline_Hard(u32 line)
 		PPU.Mode7Dirty = 0;
 		
 		PPU.CurWindowSection = &PPU.WindowSections[0];
-		PPU_ComputeWindows_Hard(&PPU.CurWindowSection->Window);
+		PPU_ComputeWindows_Hard(PPU.CurWindowSection->Window);
 		PPU.WindowDirty = 0;
 		
 		PPU.CurColorEffect = &PPU.ColorEffectSections[0];
@@ -2247,7 +2247,7 @@ void PPU_RenderScanline_Hard(u32 line)
 			PPU.CurWindowSection->EndOffset = line;
 			PPU.CurWindowSection++;
 			
-			PPU_ComputeWindows_Hard(&PPU.CurWindowSection->Window);
+			PPU_ComputeWindows_Hard(PPU.CurWindowSection->Window);
 			PPU.WindowDirty = 0;
 		}
 		

--- a/source/ppu_hard.c
+++ b/source/ppu_hard.c
@@ -24,7 +24,7 @@
 #include "mem.h"
 #include "snes.h"
 #include "ppu.h"
-#include "main.h"
+#include "ui_console.h"
 #include "config.h"
 
 

--- a/source/ppu_hard.c
+++ b/source/ppu_hard.c
@@ -1937,7 +1937,6 @@ void PPU_UpdateMode7()
 	else
 	{
 		//Examine each tile, update as necessary, then start updating all necessary layer sections
-		bool tileUpd = false;
 		for(i = 0; i < 256; i++)
 		{
 			if(PPU_M7TileFlg[i])

--- a/source/ppu_hard.c
+++ b/source/ppu_hard.c
@@ -946,8 +946,8 @@ void PPU_HardRenderBG_8x8(u32 setalpha, u32 num, int type, u32 pal, u32 prio, in
 		o = &obg->Sections[0];
 		oxoff = o->XScroll & 0xF8;
 		oyoff = o->YScroll >> yshift;
-		tilemapx = PPU.VRAM + o->TilemapOffset + ((oyoff & 0xF8) << 3);
-		tilemapy = PPU.VRAM + o->TilemapOffset + (((oyoff + 8) & 0xF8) << 3);
+		tilemapx = (u16 *)(PPU.VRAM + o->TilemapOffset + ((oyoff & 0xF8) << 3));
+		tilemapy = (u16 *)(PPU.VRAM + o->TilemapOffset + (((oyoff + 8) & 0xF8) << 3));
 		if(opt)
 		{
 			oyend = o->EndOffset;
@@ -977,7 +977,7 @@ void PPU_HardRenderBG_8x8(u32 setalpha, u32 num, int type, u32 pal, u32 prio, in
 				y = syend - 1;
 			}
 
-			tilemap = PPU.VRAM + s->TilemapOffset + ((yoff & 0xF8) << 3);
+			tilemap = (u16 *)(PPU.VRAM + s->TilemapOffset + ((yoff & 0xF8) << 3));
 			if (yoff & 0x100)
 			{
 				if (s->Size & 0x2)
@@ -1019,7 +1019,7 @@ void PPU_HardRenderBG_8x8(u32 setalpha, u32 num, int type, u32 pal, u32 prio, in
 						vval = tilemapy[idx];
 					if (hval & validBit) hofs = ox + (hval & 0x1F8) - (hval & 0x200);
 					if (vval & validBit) vofs = y + (vval & 0x1FF) - (vval & 0x200);
-					tilemap = PPU.VRAM + s->TilemapOffset + ((vofs & 0xF8) << 3);
+					tilemap = (u16 *)(PPU.VRAM + s->TilemapOffset + ((vofs & 0xF8) << 3));
 					if(vofs & 0x100) if(s->Size & 0x2) tilemap += (s->Size & 0x1) ? 2048 : 1024;
 					idx = (hofs & 0xF8) >> 3;
 					if (hofs & 0x100) if (s->Size & 0x1) idx += 1024;
@@ -1180,7 +1180,7 @@ void PPU_HardRenderBG_16x16(u32 setalpha, u32 num, int type, u32 pal, u32 prio, 
 		
 		for (y = systart - (yoff&15); y < syend; y += yincr, yoff += 16)
 		{
-			tilemap = PPU.VRAM + s->TilemapOffset + ((yoff & 0x1F0) << 2);
+			tilemap = (u16 *)(PPU.VRAM + s->TilemapOffset + ((yoff & 0x1F0) << 2));
 			if (yoff & 0x200)
 			{
 				if (s->Size & 0x2)

--- a/source/ppu_hard.c
+++ b/source/ppu_hard.c
@@ -357,12 +357,12 @@ void PPU_ConvertVRAMAll()
 	PPU_M7PalUpdate = PPU.PaletteUpdateCount256;
 }
 
-void PPU_DecodeTile(u8* src, u16* pal, u32 *dst)
+void PPU_DecodeTile(u8* src, u16* pal, u16 *dst)
 {
 	int i;
 	u16 oldcolor0 = pal[0];
 	pal[0] = 0;
-	for(i = 0; i < 64; i += 2)
+	for(i = 0; i < 64; i++)
 		*dst++ = pal[src[i]] | (pal[src[i+1]] << 16);
 	pal[0] = oldcolor0;
 }

--- a/source/ppu_hard.c
+++ b/source/ppu_hard.c
@@ -237,7 +237,7 @@ inline int bitcount(u32 val)
 {
 	val = val - ((val >> 1) & 0x55555555);                    // reuse input as temporary
 	val = (val & 0x33333333) + ((val >> 2) & 0x33333333);     // temp
-	return ((val + (val >> 4) & 0xF0F0F0F) * 0x1010101) >> 24; // count
+	return (((val + (val >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24; // count
 }
 
 void PPU_ConvertVRAM8(u32 addr, u8 val)
@@ -420,7 +420,7 @@ u32 PPU_StoreTileInCache(u32 type, u32 palid, u32 addr)
 			break;
 		
 		default:
-			bprintf("unknown tile type %d\n", type);
+			bprintf("unknown tile type %lu\n", type);
 			return 0xFFFF;
 	}
 	
@@ -2618,7 +2618,7 @@ void PPU_VBlank_Hard(int endLine)
 	u32 taken = ((u32)vertexPtr - (u32)vertexBuf);
 	GSPGPU_FlushDataCache(vertexBuf, taken);
 	if (taken > 0x200000)
-		bprintf("OVERFLOW %06X/200000 (%d%%)\n", taken, (taken*100)/0x200000);
+		bprintf("OVERFLOW %06lX/200000 (%lu%%)\n", taken, (taken*100)/0x200000);
 		
 	
 	GSPGPU_FlushDataCache(PPU_TileCache, 1024*1024*sizeof(u16));

--- a/source/rom.c
+++ b/source/rom.c
@@ -244,7 +244,7 @@ bool ROM_LoadFile(char* name)
 	if((size < 16) || (size >= 0x100000000ULL))
 	{
 		fclose(pFile);
-		bprintf("File size bad: size=%lld\n", size);
+		bprintf("File size bad: size=%ld\n", size);
 		return false;
 	}
 	ROM_FileSize = size;
@@ -288,7 +288,7 @@ bool ROM_LoadFile(char* name)
 	ROM_NumBanks = 1;
 	while (ROM_NumBanks < nbanks) ROM_NumBanks <<= 1;
 	
-	bprintf("ROM size: %dKB / %d banks\n", ((u32)size) >> 10, ROM_NumBanks);
+	bprintf("ROM size: %luKB / %lu banks\n", ((u32)size) >> 10, ROM_NumBanks);
 	
 	if (ROM_Buffer)
 	{

--- a/source/rom.c
+++ b/source/rom.c
@@ -25,6 +25,7 @@
 
 #include "cpu.h"
 #include "snes.h"
+#include "main.h"
 
 
 u8* ROM_Buffer = NULL;

--- a/source/rom.c
+++ b/source/rom.c
@@ -22,10 +22,11 @@
 #include <3ds/types.h>
 #include <3ds/services/fs.h>
 #include <3ds/svc.h>
+#include <3ds/allocator/linear.h>
 
 #include "cpu.h"
 #include "snes.h"
-#include "main.h"
+#include "ui_console.h"
 
 
 u8* ROM_Buffer = NULL;

--- a/source/rom.c
+++ b/source/rom.c
@@ -161,7 +161,6 @@ int ROM_ScoreHeader(FILE *pFile, u32 offset)
 		
 	int score = 0;
 	int i;
-	u32 bytesread;
 	
 	// 1. check opcodes at reset vector
 	

--- a/source/snes.c
+++ b/source/snes.c
@@ -128,7 +128,7 @@ bool SNES_LoadROM(char* path)
 	
 	SNES_SRAMMask = sramsize ? ((1024 << sramsize) - 1) : 0;
 	SNES_SRAMMask &= 0x000FFFFF;
-	bprintf("SRAM size: %dKB\n", (SNES_SRAMMask+1) >> 10);
+	bprintf("SRAM size: %luKB\n", (SNES_SRAMMask+1) >> 10);
 	
 	if (SNES_SRAMMask)
 	{

--- a/source/snes.c
+++ b/source/snes.c
@@ -18,6 +18,7 @@
 
 #include <3ds.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "main.h"
 #include "mem.h"

--- a/source/snes.c
+++ b/source/snes.c
@@ -94,7 +94,7 @@ u8 SNES_ExecTrap[8192] __attribute__((aligned(256)));
 void SNES_Init()
 {
 	// TODO get rid of this junk!
-	SNES_Status = &_Mem_PtrTable[0];
+	SNES_Status = (SNES_StatusData *)&_Mem_PtrTable[0];
 	Mem_PtrTable = &_Mem_PtrTable[SNESSTATUS_SIZE >> 2];
 }
 

--- a/source/snes.c
+++ b/source/snes.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "main.h"
+#include "ui_console.h"
 #include "mem.h"
 #include "snes.h"
 #include "cpu.h"

--- a/source/snes.h
+++ b/source/snes.h
@@ -138,4 +138,6 @@ void SPC_IORead(int side);
 void SPC_IOWrite(int side);
 void SPC_IOWriteDone(int side);
 
+void IO_ManualReadKeys();
+
 #endif

--- a/source/spc700io.c
+++ b/source/spc700io.c
@@ -17,10 +17,12 @@
 */
 
 #include <3ds/types.h>
+#include <string.h>
 
 #include "snes.h"
 #include "spc700.h"
 #include "dsp.h"
+#include "main.h"
 
 
 u8 SPC_ROMAccess;

--- a/source/spc700io.c
+++ b/source/spc700io.c
@@ -22,7 +22,7 @@
 #include "snes.h"
 #include "spc700.h"
 #include "dsp.h"
-#include "main.h"
+#include "ui_console.h"
 
 
 u8 SPC_ROMAccess;

--- a/source/ui.c
+++ b/source/ui.c
@@ -19,8 +19,10 @@
 // ui.c -- generic bottomscreen UI functions
 
 #include <3ds.h>
+
 #include "ui.h"
 #include "font.h"
+#include "main.h"
 
 
 UIController* CurrentUI = NULL;

--- a/source/ui.c
+++ b/source/ui.c
@@ -22,7 +22,7 @@
 
 #include "ui.h"
 #include "font.h"
-#include "main.h"
+#include "ui_console.h"
 
 
 UIController* CurrentUI = NULL;

--- a/source/ui.h
+++ b/source/ui.h
@@ -35,7 +35,9 @@ void DrawText(int x, int y, u32 color, char* str);
 
 void DrawButton(int x, int y, int width, u32 color, char* text);
 void DrawCheckBox(int x, int y, u32 color, char* text, bool check);
+void DrawToolbar(char* dir);
 
+bool HandleToolbar(u32 x, u32 y);
 
 typedef struct
 {

--- a/source/ui_config.c
+++ b/source/ui_config.c
@@ -20,6 +20,7 @@
 #include "ui.h"
 #include "config.h"
 #include "ppu.h"
+#include "ui_console.h"
 #include "main.h"
 
 int configdirty = 0;

--- a/source/ui_config.c
+++ b/source/ui_config.c
@@ -114,10 +114,10 @@ void Config_Touch(int touch, u32 x, u32 y)
 
 UIController UI_Config = 
 {
-	Config_Init,
-	Config_DeInit,
+	(void *)Config_Init,
+	(void *)Config_DeInit,
 	
-	Config_Render,
-	Config_ButtonPress,
-	Config_Touch
+	(void *)Config_Render,
+	(void *)Config_ButtonPress,
+	(void *)Config_Touch
 };

--- a/source/ui_config.c
+++ b/source/ui_config.c
@@ -19,6 +19,8 @@
 #include <3ds.h>
 #include "ui.h"
 #include "config.h"
+#include "ppu.h"
+#include "main.h"
 
 int configdirty = 0;
 

--- a/source/ui_config.c
+++ b/source/ui_config.c
@@ -20,8 +20,6 @@
 #include "ui.h"
 #include "config.h"
 
-extern badShader;
-
 int configdirty = 0;
 
 

--- a/source/ui_console.c
+++ b/source/ui_console.c
@@ -127,10 +127,10 @@ void Console_Touch(int touch, u32 x, u32 y)
 
 UIController UI_Console = 
 {
-	Console_Init,
-	Console_DeInit,
+	(void *)Console_Init,
+	(void *)Console_DeInit,
 	
-	Console_Render,
-	Console_ButtonPress,
-	Console_Touch
+	(void *)Console_Render,
+	(void *)Console_ButtonPress,
+	(void *)Console_Touch
 };

--- a/source/ui_console.h
+++ b/source/ui_console.h
@@ -1,0 +1,26 @@
+/*
+    Copyright 2014 StapleButter
+
+    This file is part of blargSnes.
+
+    blargSnes is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    blargSnes is distributed in the hope that it will be useful, but WITHOUT ANY 
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along 
+    with blargSnes. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef UI_CONSOLE_H
+#define UI_CONSOLE_H
+
+void DrawConsole();
+void ClearConsole();
+void bprintf(char* fmt, ...)  __attribute__((format(printf, 1, 2)));
+
+#endif

--- a/source/ui_rommenu.c
+++ b/source/ui_rommenu.c
@@ -20,8 +20,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <dirent.h>
+
 #include "ui.h"
 #include "config.h"
+#include "main.h"
 
 
 int nfiles;

--- a/source/ui_rommenu.c
+++ b/source/ui_rommenu.c
@@ -329,7 +329,7 @@ void ROMMenu_Init()
 
 	head = SortList(head);
 
-	fileIdx = (char**)linearAlloc(nfiles * sizeof(char*));
+	fileIdx = (struct LISTITEM**)linearAlloc(nfiles * sizeof(struct LISTITEM *));
 
 	curr = head;
 	for(i = 0; i < nfiles; i++)
@@ -533,10 +533,10 @@ void ROMMenu_Touch(int touch, u32 x, u32 y)
 
 UIController UI_ROMMenu = 
 {
-	ROMMenu_Init,
-	ROMMenu_DeInit,
+	(void *)ROMMenu_Init,
+	(void *)ROMMenu_DeInit,
 	
-	ROMMenu_Render,
-	ROMMenu_ButtonPress,
-	ROMMenu_Touch
+	(void *)ROMMenu_Render,
+	(void *)ROMMenu_ButtonPress,
+	(void *)ROMMenu_Touch
 };

--- a/source/ui_rommenu.c
+++ b/source/ui_rommenu.c
@@ -23,7 +23,7 @@
 
 #include "ui.h"
 #include "config.h"
-#include "main.h"
+#include "ui_console.h"
 
 
 int nfiles;

--- a/source/ui_rommenu.c
+++ b/source/ui_rommenu.c
@@ -191,7 +191,7 @@ bool IsGoodEntry(struct dirent *entry)
 
 void DrawROMList()
 {
-	int i, x, y, y2;
+	int i, y;
 	int maxfile;
 	int menuy;
 	


### PR DESCRIPTION
This branch fix lots of warnings reported by the GCC compiler. The majority of them are simple fixes, like missing imports, incorrect use of printf format specifiers, some wrong types, etc. A quick test seems to not break anything.

This commit disables strict-aliasing optimization too, since there is too many parts of the code that violates this rule. It can be enabled again (without the warnings) chaging `fno-strict-aliasing` to `-Wno-strict-aliasing`.

There is still some warnings, however the majority of them is now concentrated in `source/ppu_hard.c`.  I did not fix them because I have no idea how. Tried to simple cast everything, however this broke PPU a lot. Another warn is in `source/snes.c`, that seems pretty simple (can be fixed with a cast), however I decided not to do so since I don't know if this would break something.
